### PR TITLE
fix: Ensure header text 'Course Materials Assistant' is always visible

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -71,15 +71,24 @@ header::before {
 header h1 {
     font-size: 2.5rem;
     font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--text-primary);
     margin: 0;
     position: relative;
     z-index: 1;
     letter-spacing: -0.025em;
     line-height: 1.2;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Gradient text effect for supported browsers */
+@supports (background-clip: text) or (-webkit-background-clip: text) {
+    header h1 {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        color: transparent;
+    }
 }
 
 .subtitle {


### PR DESCRIPTION
Fixed CSS gradient text effect that could make the header text invisible in some browsers.

## Changes
- Added fallback color for better browser compatibility
- Used `@supports` for progressive enhancement of gradient effect
- Added text shadow for improved readability
- Ensures "Course Materials Assistant" header text is visible across all browsers

Closes #2

Generated with [Claude Code](https://claude.ai/code)